### PR TITLE
MutableResource test & invokeDescriptor conversion to tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Bugfix** Mutable `setState` this reference
 - **Minor** ResourceDescriptor now uses a default global `storeMap`
 - **Major** Refactor store events to fully represent fragment/queries
+- **Major** `Resource.fetch` and `MutableResource` methods promise value now is a tuple consisting of [result/response/descriptor]
 
 # Released
 

--- a/scripts/TestSupport.js
+++ b/scripts/TestSupport.js
@@ -57,6 +57,16 @@ global.mock_post = function(uri, response, status = 200) {
   moxios.stubRequest(`${host}${uri}`, { status, response });
 };
 
+global.mock_put = function(uri, response, status = 200) {
+  moxios_hook();
+  moxios.stubRequest(`${host}${uri}`, { status, response });
+};
+
+global.mock_delete = function(uri, response, status = 200) {
+  moxios_hook();
+  moxios.stubRequest(`${host}${uri}`, { status, response });
+};
+
 global.wait_for_promise = (fn) => {
   return new Promise((resolve, reject) => {
     const failure = setTimeout(() => {
@@ -83,7 +93,7 @@ global.wait_for_promise = (fn) => {
   });
 };
 
-global.delay_for_request = (fn) => {
+global.delay = (fn) => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       const result = fn();
@@ -93,6 +103,31 @@ global.delay_for_request = (fn) => {
       else {
         resolve();
       }
-    }, 1);
+    }, 10);
+  });
+};
+
+global.delay_for_resource_request = (resource, fn) => {
+  // pre-create our error so we can use its stack-trace when we reject
+  const err = new Error('delay timeout!');
+
+  return new Promise((resolve, reject) => {
+    let timer = null;
+    const disposer = resource.once('change', () => {
+      clearTimeout(timer);
+
+      const result = fn();
+      if (result instanceof Promise) {
+        result.then(resolve);
+      }
+      else {
+        resolve();
+      }
+    });
+
+    timer = setTimeout(() => {
+      disposer();
+      reject(err);
+    }, 500);
   });
 };

--- a/src/resource/RefraxMutableResource.js
+++ b/src/resource/RefraxMutableResource.js
@@ -9,11 +9,27 @@ const RefraxResourceBase = require('RefraxResourceBase');
 const RefraxConstants = require('RefraxConstants');
 const RefraxPath = require('RefraxPath');
 const RefraxTools = require('RefraxTools');
-const invokeDescriptor = require('invokeDescriptor');
+const requestForDescriptor = require('requestForDescriptor');
 const ACTION_CREATE = RefraxConstants.action.create;
 const ACTION_UPDATE = RefraxConstants.action.update;
 const ACTION_DELETE = RefraxConstants.action.delete;
 
+const spliceCallback = (array) => {
+  let len = array.length
+    , callback = null;
+
+  for (let i=0; i<len; i++) {
+    const arg = array[i];
+
+    if (RefraxTools.isFunction(arg)) {
+      callback = arg;
+      array.splice(i, 1);
+      len-= 1;
+    }
+  }
+
+  return callback;
+};
 
 /**
  * RefraxMutableResource is a public facing interface class to modifying through a Schema Node.
@@ -35,21 +51,27 @@ class RefraxMutableResource extends RefraxResourceBase {
     super(schemaPath, ...args);
   }
 
-  create(...data) {
-    return this._generateDescriptor(ACTION_CREATE, data, (descriptor, options) => {
-      return invokeDescriptor(descriptor, options);
+  create(...args) {
+    const callback = spliceCallback(args);
+
+    return this._generateDescriptor(ACTION_CREATE, args, (descriptor, options) => {
+      return requestForDescriptor(descriptor, options, callback);
     });
   }
 
-  destroy(...data) {
-    return this._generateDescriptor(ACTION_DELETE, data, (descriptor, options) => {
-      return invokeDescriptor(descriptor, options);
+  destroy(...args) {
+    const callback = spliceCallback(args);
+
+    return this._generateDescriptor(ACTION_DELETE, args, (descriptor, options) => {
+      return requestForDescriptor(descriptor, options, callback);
     });
   }
 
-  update(...data) {
-    return this._generateDescriptor(ACTION_UPDATE, data, (descriptor, options) => {
-      return invokeDescriptor(descriptor, options);
+  update(...args) {
+    const callback = spliceCallback(args);
+
+    return this._generateDescriptor(ACTION_UPDATE, args, (descriptor, options) => {
+      return requestForDescriptor(descriptor, options, callback);
     });
   }
 }

--- a/src/resource/RefraxResource.js
+++ b/src/resource/RefraxResource.js
@@ -9,6 +9,7 @@ const RefraxConstants = require('RefraxConstants');
 const RefraxTools = require('RefraxTools');
 const RefraxOptions = require('RefraxOptions');
 const RefraxResourceBase = require('RefraxResourceBase');
+const ACTION_GET = RefraxConstants.action.get;
 const STATUS_STALE = RefraxConstants.status.STALE;
 const STATUS_COMPLETE = RefraxConstants.status.COMPLETE;
 const TIMESTAMP_LOADING = RefraxConstants.timestamp.loading;
@@ -48,7 +49,7 @@ class RefraxResource extends RefraxResourceBase {
       this._disposeSubscriber && this._disposeSubscriber();
     });
 
-    this._generateDescriptor((descriptor, options) => {
+    this._generateDescriptor(ACTION_GET, (descriptor, options) => {
       this._dispatchLoad = (data) => {
         if (data) {
           this._dispatchLoad = null;
@@ -130,7 +131,7 @@ class RefraxResource extends RefraxResourceBase {
   invalidate(options = {}) {
     const descriptorOptions = new RefraxOptions({ errorOnInvalid: !!options.errorOnInvalid });
 
-    this._generateDescriptor(descriptorOptions, options, (descriptor, options) => {
+    this._generateDescriptor(ACTION_GET, [descriptorOptions], options, (descriptor, options) => {
       if (descriptor.store) {
         descriptor.store.invalidate(descriptor, options);
       }

--- a/src/resource/__tests__/RefraxMutableResource.spec.js
+++ b/src/resource/__tests__/RefraxMutableResource.spec.js
@@ -1,0 +1,537 @@
+/**
+ * Copyright (c) 2015-present, Joshua Hollenbeck
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const chai = require('chai');
+const sinon = require('sinon');
+const Promise = require('bluebird');
+const RefraxMutableResource = require('RefraxMutableResource');
+const RefraxOptions = require('RefraxOptions');
+const RefraxParameters = require('RefraxParameters');
+const RefraxQueryParameters = require('RefraxQueryParameters');
+const RefraxSchemaPath = require('RefraxSchemaPath');
+const RefraxSchema = require('RefraxSchema');
+const RefraxFragmentResult = require('RefraxFragmentResult');
+const RefraxConstants = require('RefraxConstants');
+const createSchemaCollection = require('createSchemaCollection');
+const ACTION_CREATE = RefraxConstants.action.create;
+const ACTION_UPDATE = RefraxConstants.action.update;
+const ACTION_DELETE = RefraxConstants.action.delete;
+const STRATEGY_MERGE = RefraxConstants.strategy.merge;
+const STRATEGY_REPLACE = RefraxConstants.strategy.replace;
+const CLASSIFY_COLLECTION = RefraxConstants.classify.collection;
+const FRAGMENT_DEFAULT = RefraxConstants.defaultFragment;
+const expect = chai.expect;
+
+/* global mock_post mock_put mock_reset mock_delete */
+/* eslint-disable no-new, indent */
+describe('RefraxMutableResource', () => {
+  let schema;
+
+  beforeEach(() => {
+    schema = new RefraxSchema();
+
+    schema.addLeaf(createSchemaCollection('users'));
+  });
+
+  describe('instantiation', () => {
+    it('should require a valid accessor', () => {
+      expect(() => {
+        new RefraxMutableResource();
+      }).to.throw(Error, 'RefraxResourceBase expected valid SchemaPath');
+
+      expect(() => {
+        new RefraxMutableResource(123);
+      }).to.throw(Error, 'RefraxResourceBase expected valid SchemaPath');
+
+      expect(() => {
+        new RefraxMutableResource('foo');
+      }).to.throw(Error, 'RefraxResourceBase expected valid SchemaPath');
+
+      expect(() => {
+        new RefraxMutableResource({foo: 'bar'});
+      }).to.throw(Error, 'RefraxResourceBase expected valid SchemaPath');
+
+      expect(() => {
+        new RefraxMutableResource(() => {});
+      }).to.throw(Error, 'RefraxResourceBase expected valid SchemaPath');
+
+      expect(() => {
+        new RefraxMutableResource(schema.users);
+      }).to.not.throw(Error);
+    });
+
+    it('should look like a ResourceBase', () => {
+      var resource = new RefraxMutableResource(schema.users);
+
+      expect(resource)
+        .to.be.instanceof(RefraxMutableResource);
+      expect(resource)
+        .to.have.property('_schemaPath')
+          .that.is.an.instanceof(RefraxSchemaPath);
+      expect(resource)
+        .to.have.property('_paths')
+          .that.is.an.instanceof(Array);
+      expect(resource)
+        .to.have.property('_options')
+          .that.is.an.instanceof(RefraxOptions);
+      expect(resource)
+        .to.have.property('_parameters')
+          .that.is.an.instanceof(RefraxParameters);
+      expect(resource)
+        .to.have.property('_queryParams')
+          .that.is.an.instanceof(RefraxQueryParameters);
+    });
+  });
+
+  describe('methods', () => {
+    let schema;
+
+    beforeEach(() => {
+      mock_reset();
+
+      schema = new RefraxSchema();
+      schema.addLeaf(createSchemaCollection('users'));
+    });
+
+    describe('create', () => {
+      const sentData = { name: 'foo joe' };
+      const responseData = { id: 1, name: 'foo joe' };
+      const expectedDescriptor = {
+        action: ACTION_CREATE,
+        basePath: '/users',
+        cacheStrategy: STRATEGY_REPLACE,
+        classify: CLASSIFY_COLLECTION,
+        collectionStrategy: STRATEGY_MERGE,
+        event: '/users',
+        fragments: [],
+        id: null,
+        params: {},
+        partial: FRAGMENT_DEFAULT,
+        path: '/users',
+        payload: sentData,
+        type: 'user',
+        valid: true
+      };
+      let resource, store;
+
+      beforeEach(() => {
+        resource = new RefraxMutableResource(schema.users);
+        store = schema.__storeMap.getOrCreate('user');
+        expectedDescriptor.store = store;
+
+        sinon.spy(resource, '_generateDescriptor');
+        sinon.spy(store, 'touchResource');
+        sinon.spy(store, 'updateResource');
+        sinon.spy(store, 'destroyResource');
+
+        mock_reset();
+        mock_post('/users', responseData);
+      });
+
+      it('returns a promise', () => {
+        const result = resource.create(sentData);
+
+        expect(result).to.be.instanceof(Promise);
+
+        return result;
+      });
+
+      it('makes a request and processes response correctly', () => {
+        return resource
+          .create(sentData)
+          .then(([result, response, descriptor]) => {
+            // promise results
+            expect(result).to.be.instanceof(RefraxFragmentResult);
+            expect(result.data).to.deep.equal([responseData]);
+            expect(response).to.have.all.keys([
+              'code',
+              'config',
+              'data',
+              'headers',
+              'request',
+              'status',
+              'statusText'
+            ]);
+            expect(descriptor).to.equal(store.touchResource.getCall(0).args[0]);
+
+            // hooks
+            expect(resource._generateDescriptor.callCount).to.equal(1);
+            expect(store.touchResource.callCount).to.equal(1);
+            expect(store.touchResource.getCall(0).args[0]).to.deep.match(expectedDescriptor);
+            expect(store.updateResource.callCount).to.equal(1);
+            expect(store.updateResource.getCall(0).args[1]).to.deep.equal(responseData);
+            expect(store.destroyResource.callCount).to.equal(0);
+          }, () => {
+            expect.fail(null, null, 'unexpected catch');
+          });
+      });
+
+      it('correctly handles a void hook', () => {
+        return resource
+          .create(sentData, (data, response, descriptor) => {
+            expect(data).to.deep.equal(responseData);
+            expect(descriptor).to.deep.match(expectedDescriptor);
+          })
+          .then(([result, response, descriptor]) => {
+            // promise results
+            expect(result).to.be.instanceof(RefraxFragmentResult);
+            expect(result.data).to.deep.equal([responseData]);
+            expect(response).to.have.all.keys([
+              'code',
+              'config',
+              'data',
+              'headers',
+              'request',
+              'status',
+              'statusText'
+            ]);
+            expect(descriptor).to.equal(store.touchResource.getCall(0).args[0]);
+
+            // hooks
+            expect(resource._generateDescriptor.callCount).to.equal(1);
+            expect(store.touchResource.callCount).to.equal(1);
+            expect(store.touchResource.getCall(0).args[0]).to.deep.match(expectedDescriptor);
+            expect(store.updateResource.callCount).to.equal(1);
+            expect(store.updateResource.getCall(0).args[1]).to.deep.equal(responseData);
+            expect(store.destroyResource.callCount).to.equal(0);
+          });
+      });
+
+      it('correctly handles return value from a hook', () => {
+        return resource
+          .create(sentData, (data, response, descriptor) => {
+            return {
+              id: data.id,
+              name: data.name.toUpperCase()
+            };
+          })
+          .then(([result, response, descriptor]) => {
+            // promise results
+            expect(result).to.be.instanceof(RefraxFragmentResult);
+            expect(result.data).to.deep.equal([{ id: 1, name: 'FOO JOE' }]);
+            expect(response).to.have.all.keys([
+              'code',
+              'config',
+              'data',
+              'headers',
+              'request',
+              'status',
+              'statusText'
+            ]);
+            expect(descriptor).to.equal(store.touchResource.getCall(0).args[0]);
+
+            // hooks
+            expect(resource._generateDescriptor.callCount).to.equal(1);
+            expect(store.touchResource.callCount).to.equal(1);
+            expect(store.touchResource.getCall(0).args[0]).to.deep.match(expectedDescriptor);
+            expect(store.updateResource.callCount).to.equal(1);
+            expect(store.updateResource.getCall(0).args[1]).to.deep.equal({
+              id: responseData.id,
+              name: responseData.name.toUpperCase()
+            });
+            expect(store.destroyResource.callCount).to.equal(0);
+          }, () => {
+            expect.fail(null, null, 'unexpected catch');
+          });
+      });
+    });
+
+    describe('destroy', () => {
+      const sentData = { name: 'foo joe' };
+      const responseData = { id: 1, name: 'foo joe' };
+      const expectedDescriptor = {
+        action: ACTION_DELETE,
+        basePath: '/users',
+        cacheStrategy: STRATEGY_REPLACE,
+        classify: CLASSIFY_COLLECTION,
+        collectionStrategy: STRATEGY_REPLACE,
+        event: '/users',
+        fragments: [],
+        id: null,
+        params: {},
+        partial: FRAGMENT_DEFAULT,
+        path: '/users',
+        payload: sentData,
+        type: 'user',
+        valid: true
+      };
+      let resource, store;
+
+      beforeEach(() => {
+        resource = new RefraxMutableResource(schema.users);
+        store = expectedDescriptor.store = schema.__storeMap.getOrCreate('user');
+
+        sinon.spy(resource, '_generateDescriptor');
+        sinon.spy(store, 'touchResource');
+        sinon.spy(store, 'updateResource');
+        sinon.spy(store, 'destroyResource');
+
+        mock_reset();
+        mock_delete('/users', responseData);
+      });
+
+      it('returns a promise', () => {
+        const result = resource.destroy(sentData);
+
+        expect(result).to.be.instanceof(Promise);
+
+        return result;
+      });
+
+      it('makes a request and processes response correctly', () => {
+        return resource
+          .destroy(sentData)
+          .then(([result, response, descriptor]) => {
+            // promise results
+            expect(result).to.be.instanceof(RefraxFragmentResult);
+            expect(result.data).to.equal(null);
+            expect(response).to.have.all.keys([
+              'code',
+              'config',
+              'data',
+              'headers',
+              'request',
+              'status',
+              'statusText'
+            ]);
+            expect(descriptor).to.equal(store.touchResource.getCall(0).args[0]);
+
+            // hooks
+            expect(resource._generateDescriptor.callCount).to.equal(1);
+            expect(store.touchResource.callCount).to.equal(1);
+            expect(store.touchResource.getCall(0).args[0]).to.deep.match(expectedDescriptor);
+            expect(store.updateResource.callCount).to.equal(0);
+            expect(store.destroyResource.callCount).to.equal(1);
+            expect(store.destroyResource.getCall(0).args[0]).to.equal(descriptor);
+            expect(store.destroyResource.getCall(0).args[1]).to.deep.equal({
+              invoker: resource
+            });
+          }, () => {
+            expect.fail(null, null, 'unexpected catch');
+          });
+      });
+
+      it('correctly handles a void hook', () => {
+        return resource
+          .destroy(sentData, (data, response, descriptor) => {
+            expect(data).to.deep.equal(responseData);
+            expect(descriptor).to.deep.match(expectedDescriptor);
+          })
+          .then(([result, response, descriptor]) => {
+            // promise results
+            expect(result).to.be.instanceof(RefraxFragmentResult);
+            expect(result.data).to.equal(null);
+            expect(response).to.have.all.keys([
+              'code',
+              'config',
+              'data',
+              'headers',
+              'request',
+              'status',
+              'statusText'
+            ]);
+            expect(descriptor).to.equal(store.touchResource.getCall(0).args[0]);
+
+            // hooks
+            expect(resource._generateDescriptor.callCount).to.equal(1);
+            expect(store.touchResource.callCount).to.equal(1);
+            expect(store.touchResource.getCall(0).args[0]).to.deep.match(expectedDescriptor);
+            expect(store.updateResource.callCount).to.equal(0);
+            expect(store.destroyResource.callCount).to.equal(1);
+            expect(store.destroyResource.getCall(0).args[0]).to.equal(descriptor);
+            expect(store.destroyResource.getCall(0).args[1]).to.deep.equal({
+              invoker: resource
+            });
+          }, () => {
+            expect.fail(null, null, 'unexpected catch');
+          });
+      });
+
+      it('correctly handles return value from a hook', () => {
+        return resource
+          .destroy(sentData, (data, response, descriptor) => {
+            return {
+              id: data.id,
+              name: data.name.toUpperCase()
+            };
+          })
+          .then(([result, response, descriptor]) => {
+            // promise results
+            expect(result).to.be.instanceof(RefraxFragmentResult);
+            expect(result.data).to.equal(null);
+            expect(response).to.have.all.keys([
+              'code',
+              'config',
+              'data',
+              'headers',
+              'request',
+              'status',
+              'statusText'
+            ]);
+            expect(descriptor).to.equal(store.touchResource.getCall(0).args[0]);
+
+            // hooks
+            expect(resource._generateDescriptor.callCount).to.equal(1);
+            expect(store.touchResource.callCount).to.equal(1);
+            expect(store.touchResource.getCall(0).args[0]).to.deep.match(expectedDescriptor);
+            expect(store.updateResource.callCount).to.equal(0);
+            expect(store.destroyResource.callCount).to.equal(1);
+            expect(store.destroyResource.getCall(0).args[0]).to.equal(descriptor);
+            expect(store.destroyResource.getCall(0).args[1]).to.deep.equal({
+              invoker: resource
+            });
+          }, () => {
+            expect.fail(null, null, 'unexpected catch');
+          });
+      });
+    });
+
+    describe('update', () => {
+      const sentData = { name: 'foo joe' };
+      const responseData = { id: 1, name: 'foo joe' };
+      const expectedDescriptor = {
+        action: ACTION_UPDATE,
+        basePath: '/users',
+        cacheStrategy: STRATEGY_REPLACE,
+        classify: CLASSIFY_COLLECTION,
+        collectionStrategy: STRATEGY_REPLACE,
+        event: '/users',
+        fragments: [],
+        id: null,
+        params: {},
+        partial: FRAGMENT_DEFAULT,
+        path: '/users',
+        payload: sentData,
+        type: 'user',
+        valid: true
+      };
+      let resource, store;
+
+      beforeEach(() => {
+        resource = new RefraxMutableResource(schema.users);
+        store = expectedDescriptor.store = schema.__storeMap.getOrCreate('user');
+
+        sinon.spy(resource, '_generateDescriptor');
+        sinon.spy(store, 'touchResource');
+        sinon.spy(store, 'updateResource');
+        sinon.spy(store, 'destroyResource');
+
+        mock_reset();
+        mock_put('/users', responseData);
+      });
+
+      it('returns a promise', () => {
+        const result = resource.update(sentData);
+
+        expect(result).to.be.instanceof(Promise);
+
+        return result;
+      });
+
+      it('makes a request and processes response correctly', () => {
+        return resource
+          .update(sentData)
+          .then(([result, response, descriptor]) => {
+            // promise results
+            expect(result).to.be.instanceof(RefraxFragmentResult);
+            expect(result.data).to.deep.equal([responseData]);
+            expect(response).to.have.all.keys([
+              'code',
+              'config',
+              'data',
+              'headers',
+              'request',
+              'status',
+              'statusText'
+            ]);
+            expect(descriptor).to.equal(store.touchResource.getCall(0).args[0]);
+
+            // hooks
+            expect(resource._generateDescriptor.callCount).to.equal(1);
+            expect(store.touchResource.callCount).to.equal(1);
+            expect(store.touchResource.getCall(0).args[0]).to.deep.match(expectedDescriptor);
+            expect(store.updateResource.callCount).to.equal(1);
+            expect(store.updateResource.getCall(0).args[1]).to.deep.equal(responseData);
+            expect(store.destroyResource.callCount).to.equal(0);
+          }, () => {
+            expect.fail(null, null, 'unexpected catch');
+          });
+      });
+
+      it('correctly handles a void hook', () => {
+        return resource
+          .update(sentData, (data, response, descriptor) => {
+            expect(data).to.deep.equal(responseData);
+            expect(descriptor).to.deep.match(expectedDescriptor);
+          })
+          .then(([result, response, descriptor]) => {
+            // promise results
+            expect(result).to.be.instanceof(RefraxFragmentResult);
+            expect(result.data).to.deep.equal([responseData]);
+            expect(response).to.have.all.keys([
+              'code',
+              'config',
+              'data',
+              'headers',
+              'request',
+              'status',
+              'statusText'
+            ]);
+            expect(descriptor).to.equal(store.touchResource.getCall(0).args[0]);
+
+            // hooks
+            expect(resource._generateDescriptor.callCount).to.equal(1);
+            expect(store.touchResource.callCount).to.equal(1);
+            expect(store.touchResource.getCall(0).args[0]).to.deep.match(expectedDescriptor);
+            expect(store.updateResource.callCount).to.equal(1);
+            expect(store.updateResource.getCall(0).args[1]).to.deep.equal(responseData);
+            expect(store.destroyResource.callCount).to.equal(0);
+          }, () => {
+            expect.fail(null, null, 'unexpected catch');
+          });
+      });
+
+      it('correctly handles return value from a hook', () => {
+        return resource
+          .update(sentData, (data, response, descriptor) => {
+            return {
+              id: data.id,
+              name: data.name.toUpperCase()
+            };
+          })
+          .then(([result, response, descriptor]) => {
+            // promise results
+            expect(result).to.be.instanceof(RefraxFragmentResult);
+            expect(result.data).to.deep.equal([{ id: 1, name: 'FOO JOE' }]);
+            expect(response).to.have.all.keys([
+              'code',
+              'config',
+              'data',
+              'headers',
+              'request',
+              'status',
+              'statusText'
+            ]);
+            expect(descriptor).to.equal(store.touchResource.getCall(0).args[0]);
+
+            // hooks
+            expect(resource._generateDescriptor.callCount).to.equal(1);
+            expect(store.touchResource.callCount).to.equal(1);
+            expect(store.touchResource.getCall(0).args[0]).to.deep.match(expectedDescriptor);
+            expect(store.updateResource.callCount).to.equal(1);
+            expect(store.updateResource.getCall(0).args[1]).to.deep.equal({
+              id: responseData.id,
+              name: responseData.name.toUpperCase()
+            });
+            expect(store.destroyResource.callCount).to.equal(0);
+          }, () => {
+            expect.fail(null, null, 'unexpected catch');
+          });
+      });
+    });
+  });
+});

--- a/src/resource/__tests__/RefraxPath.spec.js
+++ b/src/resource/__tests__/RefraxPath.spec.js
@@ -10,7 +10,7 @@ const RefraxPath = require('RefraxPath');
 const expect = chai.expect;
 
 
-/* eslint-disable no-new */
+/* eslint-disable no-new, indent */
 describe('RefraxPath', function() {
   describe('instantiation', function() {
     it('should throw an error on invalid path', function() {

--- a/src/resource/__tests__/RefraxResource.spec.js
+++ b/src/resource/__tests__/RefraxResource.spec.js
@@ -32,8 +32,8 @@ const dataCollectionUsersUpdate = [
   { id: 3, name: 'zip zoo' }
 ];
 
-/* global mock_get mock_reset mock_request_count wait_for_promise delay_for_request */
-/* eslint-disable no-new */
+/* global mock_get mock_reset mock_request_count wait_for_promise delay delay_for_resource_request */
+/* eslint-disable no-new, indent */
 describe('RefraxResource', () => {
   let schema;
 
@@ -140,7 +140,7 @@ describe('RefraxResource', () => {
             resource.subscribe('load', onLoad);
             resource.subscribe('change', onChange);
 
-            return delay_for_request(() => {
+            return delay(() => {
               // prove Resource made no request
               expect(resource.data).to.equal(null);
               expect(resource.status).to.equal(STATUS_STALE);
@@ -183,7 +183,7 @@ describe('RefraxResource', () => {
             resource.subscribe('load', onLoad);
             resource.subscribe('change', onChange);
 
-            return delay_for_request(() => {
+            return delay_for_resource_request(resource, () => {
               expect(onLoad.callCount).to.equal(1);
               expect(onChange.callCount).to.equal(1);
               expect(mock_request_count()).to.equal(1);
@@ -192,7 +192,7 @@ describe('RefraxResource', () => {
               expect(resource.timestamp).to.not.equal(TIMESTAMP_LOADING);
 
               const fragment = resource._fetchFragment();
-              return delay_for_request(() => {
+              return delay(() => {
                 expect(fragment).is.instanceof(RefraxFragmentResult);
                 expect(fragment.data).to.deep.equal(dataCollectionUsers);
                 expect(fragment.status).to.equal(STATUS_COMPLETE);
@@ -217,7 +217,7 @@ describe('RefraxResource', () => {
             resource.subscribe('load', onLoad);
             resource.subscribe('change', onChange);
 
-            return delay_for_request(() => {
+            return delay(() => {
               // prove Resource made no request
               expect(resource.data).to.equal(null);
               expect(resource.status).to.equal(STATUS_STALE);
@@ -237,7 +237,8 @@ describe('RefraxResource', () => {
               expect(onLoad.callCount).to.equal(0);
               expect(onChange.callCount).to.equal(0);
 
-              return delay_for_request(() => {
+              // no request occurs after fetching
+              return delay(() => {
                 expect(onLoad.callCount).to.equal(0);
                 expect(onChange.callCount).to.equal(0);
                 expect(resource.data).to.equal(null);
@@ -267,7 +268,7 @@ describe('RefraxResource', () => {
         expect(resource._disposeSubscriber).to.equal(undefined);
         expect(onChange.callCount).to.equal(0);
 
-        resource._generateDescriptor((descriptor) => {
+        resource._generateDescriptor(ACTION_GET, (descriptor) => {
           resource._subscribeToStore(descriptor);
         });
 
@@ -290,7 +291,7 @@ describe('RefraxResource', () => {
         const spyFetchFragment = sinon.spy(resource, '_fetchFragment');
         const spyDispatchLoad = sinon.spy(resource, '_dispatchLoad');
 
-        return delay_for_request(() => {
+        return delay(() => {
           // prove Resource made no request
           expect(resource.data).to.equal(null);
           expect(resource.status).to.equal(STATUS_STALE);
@@ -309,7 +310,7 @@ describe('RefraxResource', () => {
           expect(spyDispatchLoad.callCount).to.equal(0);
           expect(resource._dispatchLoad).to.equal(spyDispatchLoad);
 
-          return delay_for_request(() => {
+          return delay_for_resource_request(resource, () => {
             expect(resource.data).to.deep.equal(dataCollectionUsers);
             expect(resource.status).to.equal(STATUS_COMPLETE);
             expect(resource.timestamp).to.not.equal(TIMESTAMP_LOADING);
@@ -348,7 +349,7 @@ describe('RefraxResource', () => {
               expect(resource.timestamp).to.equal(TIMESTAMP_LOADING);
               expect(mock_request_count()).to.equal(1);
 
-              return delay_for_request(() => {
+              return delay_for_resource_request(resource, () => {
                 expect(mock_request_count()).to.equal(2);
                 expect(resource.status).to.equal(STATUS_COMPLETE);
                 expect(resource.timestamp).to.not.equal(TIMESTAMP_STALE);
@@ -379,7 +380,8 @@ describe('RefraxResource', () => {
               expect(resource.timestamp).to.equal(TIMESTAMP_STALE);
               expect(mock_request_count()).to.equal(1);
 
-              return delay_for_request(() => {
+              // no request occurs after invalidating
+              return delay(() => {
                 expect(mock_request_count()).to.equal(1);
                 expect(resource.status).to.equal(STATUS_STALE);
                 expect(resource.timestamp).to.equal(TIMESTAMP_STALE);

--- a/src/resource/__tests__/RefraxResourceBase.spec.js
+++ b/src/resource/__tests__/RefraxResourceBase.spec.js
@@ -26,8 +26,8 @@ const dataCollectionUsers = [
   { id: 2, name: 'foo baz' }
 ];
 
-/* global mock_get mock_reset mock_request_count wait_for_promise delay_for_request */
-/* eslint-disable no-new */
+/* global mock_get mock_reset mock_request_count wait_for_promise delay */
+/* eslint-disable no-new, indent */
 describe('RefraxResourceBase', () => {
   let schema;
 
@@ -113,7 +113,7 @@ describe('RefraxResourceBase', () => {
       describe('invoked with no arguments', () => {
         it('generates a descriptor with a default action ', () => {
           var resource = new RefraxResourceBase(schema.users)
-            , descriptor = resource._generateDescriptor();
+            , descriptor = resource._generateDescriptor(ACTION_GET);
 
           expect(descriptor.action).to.equal(ACTION_GET);
         });
@@ -137,7 +137,7 @@ describe('RefraxResourceBase', () => {
           it('should look and behave as expected', () => {
             const resource = new RefraxResourceBase(schema.users);
 
-            return delay_for_request(() => {
+            return delay(() => {
               mock_get('/users', dataCollectionUsers);
 
               expect(mock_request_count()).to.equal(0);
@@ -145,7 +145,7 @@ describe('RefraxResourceBase', () => {
               const promise = resource.fetch();
               expect(promise).is.instanceof(Promise);
 
-              return promise.then((result) => {
+              return promise.then(([result, response, descriptor]) => {
                 expect(mock_request_count()).to.equal(1);
                 expect(result).is.instanceof(RefraxFragmentResult);
                 expect(result.data).to.deep.equal(dataCollectionUsers);
@@ -158,7 +158,7 @@ describe('RefraxResourceBase', () => {
           it('should look and behave as expected', () => {
             const resource = new RefraxResourceBase(schema.users);
 
-            return delay_for_request(() => {
+            return delay(() => {
               mock_get('/users', dataCollectionUsers);
 
               expect(mock_request_count()).to.equal(0);
@@ -166,7 +166,7 @@ describe('RefraxResourceBase', () => {
               const promise = resource.fetch({ noFetchGet: true });
               expect(promise).is.instanceof(Promise);
 
-              return promise.then((result) => {
+              return promise.then(([result, response, descriptor]) => {
                 expect(mock_request_count()).to.equal(0);
                 expect(result).is.instanceof(RefraxFragmentResult);
                 expect(result.data).to.equal(null);
@@ -179,7 +179,7 @@ describe('RefraxResourceBase', () => {
           it('should look and behave as expected', () => {
             const resource = new RefraxResourceBase(schema.users);
 
-            return delay_for_request(() => {
+            return delay(() => {
               mock_get('/users', dataCollectionUsers);
 
               expect(mock_request_count()).to.equal(0);
@@ -209,7 +209,7 @@ describe('RefraxResourceBase', () => {
 
           expect(resource.fetch({ noFetchGet: true, fragmentOnly: true }).data).to.equal(null);
 
-          return resource.get().then((result) => {
+          return resource.get().then(([result, response, descriptor]) => {
             expect(result).is.instanceof(RefraxFragmentResult);
             expect(result.data).to.deep.equal(dataCollectionUsers);
           });

--- a/src/resource/__tests__/RefraxResourceDescriptor.spec.js
+++ b/src/resource/__tests__/RefraxResourceDescriptor.spec.js
@@ -7,12 +7,10 @@
  */
 const chai = require('chai');
 const RefraxResourceDescriptor = require('RefraxResourceDescriptor');
-const RefraxOptions = require('RefraxOptions');
 const RefraxParameters = require('RefraxParameters');
 const RefraxPath = require('RefraxPath');
 const RefraxQueryParameters = require('RefraxQueryParameters');
 const RefraxSchema = require('RefraxSchema');
-const RefraxSchemaPath = require('RefraxSchemaPath');
 const createSchemaCollection = require('createSchemaCollection');
 const createSchemaNamespace = require('createSchemaNamespace');
 const createSchemaResource = require('createSchemaResource');
@@ -27,7 +25,6 @@ const CLASSIFY_COLLECTION = RefraxConstants.classify.collection;
 const CLASSIFY_RESOURCE = RefraxConstants.classify.resource;
 const CLASSIFY_NAMESPACE = RefraxConstants.classify.namespace;
 const CLASSIFY_ITEM = RefraxConstants.classify.item;
-const CLASSIFY_INVALID = RefraxConstants.classify.invalid;
 const FRAGMENT_DEFAULT = RefraxConstants.defaultFragment;
 const expect = chai.expect;
 
@@ -37,7 +34,7 @@ describe('RefraxResourceDescriptor', () => {
   describe('instantiation', () => {
     describe('with no arguments', () => {
       it('should have correct shape default for GET', () => {
-        const descriptor = new RefraxResourceDescriptor(null, );
+        const descriptor = new RefraxResourceDescriptor(null, ACTION_GET);
 
         expect(descriptor).to.deep.match({
           action: ACTION_GET,


### PR DESCRIPTION
This PR adds `MutableResource` tests and renamed `invokeDescriptor` => `requestForDescriptor` and converted success value to tuple of `result/response/descriptor`.