### PR TITLE
Add Adapter support for Schema (XHR/Local/Session)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -192,5 +192,5 @@ rules:
   max-len: 0
   max-params: 0
   max-statements: 0
-  no-bitwise: 1
+  no-bitwise: 0
   no-plusplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Major** Refactor store events to fully represent fragment/queries
 - **Major** `Resource.fetch` and `MutableResource` methods promise value now is a tuple consisting of [result/response/descriptor]
 - **Major** Added RefraxReact `createContainer` to supersede it's `Mixin` use
+- **Feature** Added Schema `adapter` support with `XHRAdapter` / `LocalStorageAdapter` / `SessionStorageAdapter`
 
 # Released
 

--- a/scripts/AxiosMock.js
+++ b/scripts/AxiosMock.js
@@ -14,6 +14,10 @@ import btoa from 'axios/lib/helpers/btoa';
 import cookies from 'axios/lib/helpers/cookies';
 import settle from 'axios/lib/core/settle';
 
+Promise.config({
+  longStackTraces: true
+});
+
 // The default adapter
 let defaultAdapter;
 
@@ -25,10 +29,6 @@ let defaultAdapter;
  * @param {Object} config The config object to be used for the request
  */
 const mockAdapter = (config) => {
-  Promise.config({
-    longStackTraces: true
-  });
-
   return new Promise(function(resolve, reject) {
     const request = new Request(resolve, reject, config);
     axiosMock.requests.track(request);

--- a/scripts/TestSupport.js
+++ b/scripts/TestSupport.js
@@ -14,6 +14,19 @@ global.document = window.document;
 global.navigator = {
   userAgent: 'node.js'
 };
+// JSDOM "polyfill" for storage
+window.localStorage = window.sessionStorage = {
+  __storage: {},
+  getItem: function(key) {
+    return this.__storage[key] || null;
+  },
+  setItem: function(key, value) {
+    this.__storage[key] = '' + value;
+  },
+  removeItem: function(key, value) {
+    delete this.__storage[key];
+  }
+};
 
 let fn_mount = null
   , mounted = [];
@@ -53,6 +66,7 @@ const host = '';
 global.mock_reset = () => {
   axiosMock.requests.reset();
   axiosMock.stubs.reset();
+  window.localStorage.__storage = {};
 };
 
 global.mock_request_count = () => {

--- a/src/Refrax.js
+++ b/src/Refrax.js
@@ -16,6 +16,10 @@ const createAction = require('createAction');
 const createSchemaCollection = require('createSchemaCollection');
 const createSchemaResource = require('createSchemaResource');
 const createSchemaNamespace = require('createSchemaNamespace');
+const RefraxAdapter = require('RefraxAdapter');
+const XHRAdapter = require('XHRAdapter');
+const LocalStorageAdapter = require('LocalStorageAdapter');
+const SessionStorageAdapter = require('SessionStorageAdapter');
 const processResponse = require('processResponse');
 const invalidateHelper = require('invalidateHelper');
 const RefraxStore = require('RefraxStore');
@@ -35,5 +39,9 @@ export default {
   createSchemaResource,
   createSchemaNamespace,
   processResponse,
-  invalidate: invalidateHelper
+  invalidate: invalidateHelper,
+  Adapter: RefraxAdapter,
+  XHRAdapter,
+  LocalStorageAdapter,
+  SessionStorageAdapter
 };

--- a/src/adapters/LocalStorageAdapter.js
+++ b/src/adapters/LocalStorageAdapter.js
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) 2015-present, Joshua Hollenbeck
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const Promise = require('bluebird');
+const RequestError = require('RequestError');
+const RefraxResourceDescriptor = require('RefraxResourceDescriptor');
+const RefraxAdapter = require('RefraxAdapter');
+const RefraxTools = require('RefraxTools');
+const RefraxConstants = require('RefraxConstants');
+const ACTION_GET = RefraxConstants.action.get;
+const ACTION_CREATE = RefraxConstants.action.create;
+const ACTION_UPDATE = RefraxConstants.action.update;
+const ACTION_DELETE = RefraxConstants.action.delete;
+const CLASSIFY_COLLECTION = RefraxConstants.classify.collection;
+const CLASSIFY_ITEM = RefraxConstants.classify.item;
+
+
+function decodeGet(localStorage, key) {
+  return JSON.parse(localStorage.getItem(key));
+}
+
+function encodeSet(localStorage, key, data) {
+  return localStorage.setItem(key, JSON.stringify(data));
+}
+
+function getCollection(localStorage, key) {
+  return decodeGet(localStorage, key) || { list: [], guid: 0 };
+}
+
+function asString(value) {
+  return ('' + value);
+}
+
+// Essentially just blindly accepts data and uses merge/replace strategies where applicable
+class LocalStorageAdapter extends RefraxAdapter {
+  constructor(config = {}) {
+    super(config);
+
+    this.storage = global.localStorage || global.window && global.window.localStorage;
+  }
+
+  invoke(descriptor, options = {}) {
+    if (!(descriptor instanceof RefraxResourceDescriptor)) {
+      throw new TypeError(
+        `StorageAdapter expected descriptor, but found \`${descriptor}\``
+      );
+    }
+
+    const storage = this.storage;
+    if (!storage) {
+      throw new ReferenceError(
+        'StorageAdapter no storage reference'
+      );
+    }
+
+    const response = {
+      data: null,
+      status: 200,
+      request: {
+        url: descriptor.basePath
+      }
+    };
+    let result = null;
+
+    if (descriptor.action === ACTION_GET) {
+      if (descriptor.classify === CLASSIFY_COLLECTION) {
+        result = getCollection(storage, descriptor.basePath).list;
+      }
+      else {
+        result = decodeGet(storage, descriptor.basePath);
+      }
+
+      if (!result) {
+        response.status = 404;
+        return Promise.reject(new RequestError(response));
+      }
+
+      response.data = result;
+      return Promise.resolve([response.data, response, descriptor]);
+    }
+    else if (descriptor.action === ACTION_CREATE ||
+             descriptor.action === ACTION_UPDATE) {
+      let data = descriptor.payload;
+
+      if (descriptor.classify === CLASSIFY_COLLECTION) {
+        const collection = getCollection(storage, descriptor.collectionPath);
+
+        if (descriptor.action === ACTION_CREATE) {
+          data = RefraxTools.extend({}, data, { id: ++collection.guid });
+          collection.list.push(data);
+          encodeSet(storage, descriptor.collectionPath + '/' + data.id, data);
+        }
+        else {
+          collection.list = data;
+
+          let maxId = collection.guid;
+          // Apply each item in the array into item spots based on collectionPath
+          for (let i = 0, length = collection.list.length; i < length; i++) {
+            let item = collection.list[i];
+
+            if (item.id) {
+              const itemKey = descriptor.collectionPath + '/' + item.id;
+              const existingItem = decodeGet(storage, itemKey) || {};
+
+              collection.list[i] = item = RefraxTools.extend(item, existingItem);
+              encodeSet(storage, descriptor.collectionPath + '/' + item.id, item);
+
+              // Attempt to maintain a proper GUID
+              if (item.id > maxId) {
+                maxId = item.id;
+              }
+            }
+          }
+
+          collection.guid = maxId;
+        }
+
+        encodeSet(storage, descriptor.basePath, collection);
+      }
+      else if (descriptor.classify === CLASSIFY_ITEM) {
+        const collection = getCollection(storage, descriptor.collectionPath);
+
+        // It's not really "proper" to create on the ITEM endpoint itself but we do it anyways..
+        if (descriptor.action === ACTION_CREATE) {
+          data = RefraxTools.extend({}, data, { id: (parseInt(descriptor.id, 10) || ++collection.guid) });
+          collection.list.push(data);
+          encodeSet(storage, descriptor.collectionPath + '/' + data.id, data);
+        }
+
+        let maxId = collection.guid
+          , i
+          , length;
+        for (i = 0, length = collection.list.length; i < length; i++) {
+          const item = collection.list[i];
+
+          if (asString(item.id) === asString(descriptor.id)) {
+            data = collection.list[i] = RefraxTools.extend(item, data);
+            encodeSet(storage, descriptor.basePath, data);
+
+            // Attempt to maintain a proper GUID
+            if (item.id > maxId) {
+              maxId = item.id;
+            }
+            break;
+          }
+        }
+        if (i >= length) {
+          collection.list.push(data);
+
+          if (data.id && data.id > maxId) {
+            maxId = data.id;
+          }
+        }
+        collection.guid = maxId;
+
+        encodeSet(storage, descriptor.collectionPath, collection);
+        encodeSet(storage, descriptor.basePath, data);
+      }
+      else {
+        encodeSet(storage, descriptor.basePath, data);
+      }
+
+      response.data = data;
+      return Promise.resolve([response.data, response, descriptor]);
+    }
+    else if (descriptor.action === ACTION_DELETE) {
+      if (descriptor.classify === CLASSIFY_ITEM) {
+        const collection = getCollection(storage, descriptor.collectionPath);
+
+        for (let i = 0, length = collection.list.length; i < length; i++) {
+          const item = collection.list[i];
+
+          if (asString(item.id) === asString(descriptor.id)) {
+            collection.list.splice(i, 1);
+            encodeSet(storage, descriptor.collectionPath, collection);
+            break;
+          }
+        }
+      }
+
+      storage.removeItem(descriptor.basePath);
+      return Promise.resolve([response.data, response, descriptor]);
+    }
+    else {
+      throw new TypeError(
+        `StorageAdapter unexpected descriptor action \`${descriptor.action}\``
+      );
+    }
+  }
+}
+
+export default LocalStorageAdapter;

--- a/src/adapters/RefraxAdapter.js
+++ b/src/adapters/RefraxAdapter.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2015-present, Joshua Hollenbeck
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const RefraxTools = require('RefraxTools');
+
+
+function validateConfig(config) {
+  if (!RefraxTools.isPlainObject(config)) {
+    throw new TypeError(
+      'RefraxAdapter - You\'re attempting to pass an invalid config of type `' + typeof(config) + '`. ' +
+      'A valid config type is a regular object.'
+    );
+  }
+}
+
+class RefraxAdapter {
+  constructor(config = {}) {
+    validateConfig(config);
+
+    Object.defineProperty(this, 'config', { value: config });
+  }
+
+  invoke() {
+    throw new Error('RefraxAdapter(%s) missing invoke override', this.constructor.name || this.toString());
+  }
+}
+
+export default RefraxAdapter;

--- a/src/adapters/SessionStorageAdapter.js
+++ b/src/adapters/SessionStorageAdapter.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2015-present, Joshua Hollenbeck
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const LocalStorageAdapter = require('LocalStorageAdapter');
+
+
+class SessionStorageAdapter extends LocalStorageAdapter {
+  constructor(config = {}) {
+    super(config);
+
+    this.storage = global.sessionStorage || global.window && global.window.sessionStorage;
+  }
+}
+
+export default SessionStorageAdapter;

--- a/src/adapters/XHRAdapter.js
+++ b/src/adapters/XHRAdapter.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2015-present, Joshua Hollenbeck
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const Promise = require('bluebird');
+const Axios = require('axios');
+const RefraxResourceDescriptor = require('RefraxResourceDescriptor');
+const RefraxAdapter = require('RefraxAdapter');
+const RefraxTools = require('RefraxTools');
+const RequestError = require('RequestError');
+const RefraxConstants = require('RefraxConstants');
+const ACTION_GET = RefraxConstants.action.get;
+const STATUS_STALE = RefraxConstants.status.stale;
+const TIMESTAMP_LOADING = RefraxConstants.timestamp.loading;
+
+
+function containsMultipart(data) {
+  return data && RefraxTools.any(data, function(value) {
+    return global.File && value instanceof global.File;
+  });
+}
+
+function composeFormData(data) {
+  const result = new global.FormData();
+
+  RefraxTools.each(data, function(value, key) {
+    result.append(key, value);
+  });
+
+  return result;
+}
+
+class XHRAdapter extends RefraxAdapter {
+  invoke(descriptor, options = {}) {
+    if (!(descriptor instanceof RefraxResourceDescriptor)) {
+      throw new TypeError(
+        `xhrAdapter expected descriptor, but found \`${descriptor}\``
+      );
+    }
+
+    const store = descriptor.store;
+    const touchParams = {
+      timestamp: TIMESTAMP_LOADING
+    };
+    const requestConfig = {
+      method: descriptor.action,
+      url: descriptor.path
+    };
+
+    if (descriptor.action === ACTION_GET) {
+      touchParams.status = STATUS_STALE;
+    }
+    else {
+      requestConfig.data = descriptor.payload;
+
+      if (containsMultipart(requestConfig.data)) {
+        requestConfig.data = composeFormData(requestConfig.data);
+      }
+    }
+
+    if (store) {
+      store.touchResource(descriptor, touchParams, options);
+    }
+
+    return new Promise(function(resolve, reject) {
+      // eslint-disable-next-line new-cap
+      Axios(requestConfig)
+        .then(function(response) {
+          resolve([response.data || null, response, descriptor]);
+        }, function(err) {
+          // Convert errors that look like Axios request errors into Refrax request errors
+          if ('request' in err && 'response' in err) {
+            reject(new RequestError(err.response));
+          }
+          else {
+            reject(err);
+          }
+        });
+    });
+  }
+}
+
+export default XHRAdapter;

--- a/src/adapters/__tests__/LocalStorageAdapter.spec.js
+++ b/src/adapters/__tests__/LocalStorageAdapter.spec.js
@@ -1,0 +1,339 @@
+/**
+ * Copyright (c) 2015-present, Joshua Hollenbeck
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const chai = require('chai');
+const sinon = require('sinon');
+const Promise = require('bluebird');
+const LocalStorageAdapter = require('LocalStorageAdapter');
+const RefraxResourceDescriptor = require('RefraxResourceDescriptor');
+const RefraxSchema = require('RefraxSchema');
+const RefraxParameters = require('RefraxParameters');
+const RefraxTools = require('RefraxTools');
+const RefraxConstants = require('RefraxConstants');
+const createSchemaCollection = require('createSchemaCollection');
+const createSchemaResource = require('createSchemaResource');
+const ACTION_GET = RefraxConstants.action.get;
+const ACTION_CREATE = RefraxConstants.action.create;
+const ACTION_DELETE = RefraxConstants.action.delete;
+const ACTION_UPDATE = RefraxConstants.action.update;
+const expect = chai.expect;
+
+const dataUser1 = { id: 1, name: 'foo bob' };
+const dataUser2 = { id: 2, name: 'foo baz' };
+const dataUser3 = { id: 3, name: 'foo sue' };
+const dataCollectionUsers = [
+  dataUser1,
+  dataUser2
+];
+const dataRules = {
+  foo: 'bar',
+  zip: 123
+};
+
+/* global mock_reset */
+/* eslint-disable no-new, indent */
+describe('LocalStorageAdapter', () => {
+  let schema
+    , storeUsers
+    , storeRules
+    , adapter;
+
+  beforeEach(() => {
+    mock_reset();
+
+    adapter = new LocalStorageAdapter();
+    schema = new RefraxSchema({ adapter: adapter });
+    schema.addLeaf(createSchemaCollection('users'));
+    schema.addLeaf(createSchemaResource('rules'));
+
+    storeUsers = schema.__node.definition.storeMap.getOrCreate('user');
+    sinon.spy(storeUsers, 'touchResource');
+    sinon.spy(storeUsers, 'updateResource');
+
+    storeRules = schema.__node.definition.storeMap.getOrCreate('rule');
+    sinon.spy(storeRules, 'touchResource');
+    sinon.spy(storeRules, 'updateResource');
+  });
+
+  describe('instantiation', () => {
+    it('should not accept invalid arguments', () => {
+      expect(() => {
+        new LocalStorageAdapter(123);
+      }).to.throw(TypeError, 'attempting to pass an invalid config of type');
+
+      expect(() => {
+        new LocalStorageAdapter(() => {});
+      }).to.throw(TypeError, 'attempting to pass an invalid config of type');
+
+      expect(() => {
+        new LocalStorageAdapter('foo');
+      }).to.throw(TypeError, 'attempting to pass an invalid config of type');
+    });
+
+    it('should accept valid arguments', () => {
+      expect(() => {
+        new LocalStorageAdapter();
+      }).to.not.throw(Error);
+
+      expect(() => {
+        new LocalStorageAdapter({ foo: 123 });
+      }).to.not.throw(Error);
+    });
+  });
+
+  describe('methods', () => {
+    describe('invoke', () => {
+      const invokeTestHelper = (action, stack, options) => {
+        const {
+          seed,
+          params,
+          payload,
+          expectedSignal,
+          expectedStorage
+        } = options;
+
+        stack = [].concat(stack, new RefraxParameters(params));
+        const descriptor = new RefraxResourceDescriptor(null, action, stack);
+        descriptor.payload = payload;
+
+        if (seed) {
+          RefraxTools.each(seed, (value, key) => {
+            global.window.localStorage.setItem(key, JSON.stringify(value));
+          });
+        }
+
+        const promise = adapter.invoke(descriptor);
+
+        expect(promise).to.be.instanceof(Promise);
+
+        return promise
+          .then((result) => {
+            expect(storeUsers.touchResource.callCount).to.equal(0);
+            expect(storeUsers.updateResource.callCount).to.equal(0);
+            expect(storeRules.touchResource.callCount).to.equal(0);
+            expect(storeRules.updateResource.callCount).to.equal(0);
+            expect(result).to.be.a('array');
+            expect(result.length).to.equal(3);
+            expect(result[0]).to.deep.equal(expectedSignal);
+            expect(result[1]).to.deep.match({
+              data: expectedSignal,
+              request: Object,
+              status: 200
+            });
+            expect(result[2]).to.equal(descriptor);
+
+            if (expectedStorage) {
+              if (RefraxTools.keysFor(expectedStorage).length === 0) {
+                expect(window.localStorage.__storage).to.be.empty;
+              }
+              else {
+                expect(window.localStorage.__storage)
+                  .to.have.all.keys(RefraxTools.keysFor(expectedStorage));
+              }
+
+              RefraxTools.each(window.localStorage.__storage, (encoded, key) => {
+                expect(JSON.parse(encoded)).to.deep.equal(expectedStorage[key], key);
+              });
+            }
+          });
+      };
+
+      it('should not accept invalid arguments', () => {
+        expect(() => {
+          adapter.invoke();
+        }).to.throw(TypeError, 'expected descriptor, but found');
+
+        expect(() => {
+          adapter.invoke(123);
+        }).to.throw(TypeError, 'expected descriptor, but found');
+
+        expect(() => {
+          adapter.invoke({ foo: 123 });
+        }).to.throw(TypeError, 'expected descriptor, but found');
+
+        expect(() => {
+          adapter.invoke('foo');
+        }).to.throw(TypeError, 'expected descriptor, but found');
+      });
+
+      describe('with a Collection descriptor', () => {
+        describe('using action GET', () => {
+          it('should correctly fetch', () => {
+            return invokeTestHelper(ACTION_GET, schema.users.__stack, {
+              seed: {
+                '/users': { list: dataCollectionUsers, guid: 2 },
+                '/users/1': dataUser1,
+                '/users/2': dataUser2
+              },
+              expectedSignal: dataCollectionUsers
+            });
+          });
+        });
+
+        describe('using action CREATE', () => {
+          it('should correctly create entries', () => {
+            const expected = {
+              id: 1,
+              name: 'bob foo'
+            };
+
+            return invokeTestHelper(ACTION_CREATE, schema.users.__stack, {
+              payload: { name: expected.name },
+              expectedSignal: expected,
+              expectedStorage: {
+                '/users': { list: [expected], guid: 1 },
+                '/users/1': expected
+              }
+            });
+          });
+        });
+
+        describe('using action UPDATE', () => {
+          it('should correctly update entries', () => {
+            return invokeTestHelper(ACTION_UPDATE, schema.users.__stack, {
+              payload: [dataUser3],
+              expectedSignal: [dataUser3],
+              expectedStorage: {
+                '/users': { list: [dataUser3], guid: 3 },
+                '/users/3': dataUser3
+              }
+            });
+          });
+        });
+
+        describe('using action DELETE', () => {
+          it('should correctly remove entries', () => {
+            return invokeTestHelper(ACTION_DELETE, schema.users.__stack, {
+              seed: {
+                '/users': { list: dataCollectionUsers, guid: 2 },
+                '/users/1': dataUser1,
+                '/users/2': dataUser2
+              },
+              expectedSignal: null,
+              expectedStorage: {
+                '/users/1': dataUser1,
+                '/users/2': dataUser2
+              }
+            });
+          });
+        });
+      });
+
+      describe('with a Collection Item descriptor', () => {
+        describe('using action GET', () => {
+          it('should correctly fetch', () => {
+            return invokeTestHelper(ACTION_GET, schema.users.user.__stack, {
+              params: { userId: 1 },
+              seed: {
+                '/users': { list: dataCollectionUsers, guid: 2 },
+                '/users/1': dataUser1,
+                '/users/2': dataUser2
+              },
+              expectedSignal: dataUser1
+            });
+          });
+        });
+
+        describe('using action CREATE', () => {
+          it('should correctly create entries', () => {
+            return invokeTestHelper(ACTION_CREATE, schema.users.user.__stack, {
+              params: { userId: 3 },
+              payload: { name: dataUser3.name },
+              expectedSignal: dataUser3,
+              expectedStorage: {
+                '/users': { list: [dataUser3], guid: 3 },
+                '/users/3': dataUser3
+              }
+            });
+          });
+        });
+
+        describe('using action UPDATE', () => {
+          it('should correctly update entries', () => {
+            return invokeTestHelper(ACTION_UPDATE, schema.users.user.__stack, {
+              params: { userId: 3 },
+              payload: dataUser3,
+              expectedSignal: dataUser3,
+              expectedStorage: {
+                '/users': { list: [dataUser3], guid: 3 },
+                '/users/3': dataUser3
+              }
+            });
+          });
+        });
+
+        describe('using action DELETE', () => {
+          it('should correctly remove entries', () => {
+            return invokeTestHelper(ACTION_DELETE, schema.users.user.__stack, {
+              params: { userId: 2 },
+              seed: {
+                '/users': { list: dataCollectionUsers, guid: 2 },
+                '/users/1': dataUser1,
+                '/users/2': dataUser2
+              },
+              expectedSignal: null,
+              expectedStorage: {
+                '/users': { list: [dataUser1], guid: 2 },
+                '/users/1': dataUser1
+              }
+            });
+          });
+        });
+      });
+
+      describe('with a Resource descriptor', () => {
+        describe('using action GET', () => {
+          it('should correctly fetch', () => {
+            return invokeTestHelper(ACTION_GET, schema.rules.__stack, {
+              seed: {
+                '/rules': dataRules
+              },
+              expectedSignal: dataRules
+            });
+          });
+        });
+
+        describe('using action CREATE', () => {
+          it('should correctly create entries', () => {
+            return invokeTestHelper(ACTION_CREATE, schema.rules.__stack, {
+              payload: dataRules,
+              expectedSignal: dataRules,
+              expectedStorage: {
+                '/rules': dataRules
+              }
+            });
+          });
+        });
+
+        describe('using action UPDATE', () => {
+          it('should correctly update entries', () => {
+            return invokeTestHelper(ACTION_UPDATE, schema.rules.__stack, {
+              payload: dataRules,
+              expectedSignal: dataRules,
+              expectedStorage: {
+                '/rules': dataRules
+              }
+            });
+          });
+        });
+
+        describe('using action DELETE', () => {
+          it('should correctly remove entries', () => {
+            return invokeTestHelper(ACTION_DELETE, schema.rules.__stack, {
+              seed: {
+                '/rules': dataRules
+              },
+              expectedSignal: null,
+              expectedStorage: {
+              }
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/adapters/__tests__/XHRAdapter.spec.js
+++ b/src/adapters/__tests__/XHRAdapter.spec.js
@@ -1,0 +1,293 @@
+/**
+ * Copyright (c) 2015-present, Joshua Hollenbeck
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const chai = require('chai');
+const sinon = require('sinon');
+const Promise = require('bluebird');
+const XHRAdapter = require('XHRAdapter');
+const RefraxResourceDescriptor = require('RefraxResourceDescriptor');
+const RefraxSchema = require('RefraxSchema');
+const RefraxParameters = require('RefraxParameters');
+const RefraxConstants = require('RefraxConstants');
+const createSchemaCollection = require('createSchemaCollection');
+const createSchemaResource = require('createSchemaResource');
+const ACTION_GET = RefraxConstants.action.get;
+const ACTION_CREATE = RefraxConstants.action.create;
+const ACTION_DELETE = RefraxConstants.action.delete;
+const ACTION_UPDATE = RefraxConstants.action.update;
+const expect = chai.expect;
+
+
+const dataUser1 = { id: 1, name: 'foo bob' };
+const dataUser2 = { id: 2, name: 'foo baz' };
+const dataUser3 = { id: 3, name: 'foo sue' };
+const dataCollectionUsers = [
+  dataUser1,
+  dataUser2
+];
+const dataRules = {
+  foo: 'bar',
+  zip: 123
+};
+
+/* global mock_reset mock_get mock_put mock_post mock_delete */
+/* eslint-disable no-new, indent */
+describe('XHRAdapter', () => {
+  let schema
+    , storeUsers
+    , storeRules
+    , adapter;
+
+  beforeEach(() => {
+    mock_reset();
+
+    adapter = new XHRAdapter();
+    schema = new RefraxSchema({ adapter: adapter });
+    schema.addLeaf(createSchemaCollection('users'));
+    schema.addLeaf(createSchemaResource('rules'));
+
+    storeUsers = schema.__node.definition.storeMap.getOrCreate('user');
+    sinon.spy(storeUsers, 'touchResource');
+    sinon.spy(storeUsers, 'updateResource');
+
+    storeRules = schema.__node.definition.storeMap.getOrCreate('rule');
+    sinon.spy(storeRules, 'touchResource');
+    sinon.spy(storeRules, 'updateResource');
+  });
+
+
+  describe('instantiation', () => {
+    it('should not accept invalid arguments', () => {
+      expect(() => {
+        new XHRAdapter(123);
+      }).to.throw(TypeError, 'attempting to pass an invalid config of type');
+
+      expect(() => {
+        new XHRAdapter(() => {});
+      }).to.throw(TypeError, 'attempting to pass an invalid config of type');
+
+      expect(() => {
+        new XHRAdapter('foo');
+      }).to.throw(TypeError, 'attempting to pass an invalid config of type');
+    });
+
+    it('should accept valid arguments', () => {
+      expect(() => {
+        new XHRAdapter();
+      }).to.not.throw(Error);
+
+      expect(() => {
+        new XHRAdapter({ foo: 123 });
+      }).to.not.throw(Error);
+    });
+  });
+
+  describe('methods', () => {
+    describe('invoke', () => {
+      const invokeTestHelper = (action, stack, options) => {
+        const {
+          params,
+          payload,
+          expectedSignal
+        } = options;
+
+        stack = [].concat(stack, new RefraxParameters(params));
+        const descriptor = new RefraxResourceDescriptor(null, action, stack);
+        descriptor.payload = payload;
+
+        const promise = adapter.invoke(descriptor);
+
+        expect(promise).to.be.instanceof(Promise);
+
+        return promise
+          .then((result) => {
+            expect(storeUsers.touchResource.callCount).to.equal(descriptor.store === storeUsers ? 1 : 0);
+            expect(storeUsers.updateResource.callCount).to.equal(0);
+            expect(storeRules.touchResource.callCount).to.equal(descriptor.store === storeRules ? 1 : 0);
+            expect(storeRules.updateResource.callCount).to.equal(0);
+            expect(result).to.be.a('array');
+            expect(result.length).to.equal(3);
+            expect(result[0]).to.deep.equal(expectedSignal);
+
+            if (descriptor.action === ACTION_DELETE) {
+              expect(result[1]).to.deep.match({
+                request: Object,
+                status: 200
+              });
+            }
+            else {
+              expect(result[1]).to.deep.match({
+                data: expectedSignal,
+                request: Object,
+                status: 200
+              });
+            }
+            expect(result[2]).to.equal(descriptor);
+          });
+      };
+
+      it('should not accept invalid arguments', () => {
+        expect(() => {
+          adapter.invoke();
+        }).to.throw(TypeError, 'expected descriptor, but found');
+
+        expect(() => {
+          adapter.invoke(123);
+        }).to.throw(TypeError, 'expected descriptor, but found');
+
+        expect(() => {
+          adapter.invoke({ foo: 123 });
+        }).to.throw(TypeError, 'expected descriptor, but found');
+
+        expect(() => {
+          adapter.invoke('foo');
+        }).to.throw(TypeError, 'expected descriptor, but found');
+      });
+
+      describe('with a Collection descriptor', () => {
+        describe('using action GET', () => {
+          it('should correctly fetch', () => {
+            mock_get('/users', dataCollectionUsers);
+
+            return invokeTestHelper(ACTION_GET, schema.users.__stack, {
+              expectedSignal: dataCollectionUsers
+            });
+          });
+        });
+
+        describe('using action CREATE', () => {
+          it('should correctly create entries', () => {
+            const expected = {
+              id: 1,
+              name: 'bob foo'
+            };
+
+            mock_post('/users', expected);
+
+            return invokeTestHelper(ACTION_CREATE, schema.users.__stack, {
+              payload: { name: expected.name },
+              expectedSignal: expected
+            });
+          });
+        });
+
+        describe('using action UPDATE', () => {
+          it('should correctly update entries', () => {
+            mock_put('/users', [dataUser3]);
+
+            return invokeTestHelper(ACTION_UPDATE, schema.users.__stack, {
+              payload: [dataUser3],
+              expectedSignal: [dataUser3]
+            });
+          });
+        });
+
+        describe('using action DELETE', () => {
+          it('should correctly remove entries', () => {
+            mock_delete('/users');
+
+            return invokeTestHelper(ACTION_DELETE, schema.users.__stack, {
+              expectedSignal: null
+            });
+          });
+        });
+      });
+
+      describe('with a Collection Item descriptor', () => {
+        describe('using action GET', () => {
+          it('should correctly fetch', () => {
+            mock_get('/users/1', dataUser1);
+
+            return invokeTestHelper(ACTION_GET, schema.users.user.__stack, {
+              params: { userId: 1 },
+              expectedSignal: dataUser1
+            });
+          });
+        });
+
+        describe('using action CREATE', () => {
+          it('should correctly create entries', () => {
+            mock_post('/users/3', dataUser3);
+
+            return invokeTestHelper(ACTION_CREATE, schema.users.user.__stack, {
+              params: { userId: 3 },
+              payload: dataUser3,
+              expectedSignal: dataUser3
+            });
+          });
+        });
+
+        describe('using action UPDATE', () => {
+          it('should correctly update entries', () => {
+            mock_put('/users/3', dataUser3);
+
+            return invokeTestHelper(ACTION_UPDATE, schema.users.user.__stack, {
+              params: { userId: 3 },
+              payload: dataUser3,
+              expectedSignal: dataUser3
+            });
+          });
+        });
+
+        describe('using action DELETE', () => {
+          it('should correctly remove entries', () => {
+            mock_delete('/users/2');
+
+            return invokeTestHelper(ACTION_DELETE, schema.users.user.__stack, {
+              params: { userId: 2 },
+              expectedSignal: null
+            });
+          });
+        });
+      });
+
+      describe('with a Resource descriptor', () => {
+        describe('using action GET', () => {
+          it('should correctly fetch', () => {
+            mock_get('/rules', dataRules);
+
+            return invokeTestHelper(ACTION_GET, schema.rules.__stack, {
+              expectedSignal: dataRules
+            });
+          });
+        });
+
+        describe('using action CREATE', () => {
+          it('should correctly create entries', () => {
+            mock_post('/rules', dataRules);
+
+            return invokeTestHelper(ACTION_CREATE, schema.rules.__stack, {
+              payload: dataRules,
+              expectedSignal: dataRules
+            });
+          });
+        });
+
+        describe('using action UPDATE', () => {
+          it('should correctly update entries', () => {
+            mock_put('/rules', dataRules);
+
+            return invokeTestHelper(ACTION_UPDATE, schema.rules.__stack, {
+              payload: dataRules,
+              expectedSignal: dataRules
+            });
+          });
+        });
+
+        describe('using action DELETE', () => {
+          it('should correctly remove entries', () => {
+            mock_delete('/rules');
+
+            return invokeTestHelper(ACTION_DELETE, schema.rules.__stack, {
+              expectedSignal: null
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/addons/__tests__/RefraxContainer.spec.js
+++ b/src/addons/__tests__/RefraxContainer.spec.js
@@ -305,7 +305,7 @@ describe('RefraxContainer', function() {
     it('should update and propagate properly when invalidated externally', () => {
       const onLoad = sinon.spy();
       const onChange = sinon.spy();
-      const storeUsers = schema.__storeMap.getOrCreate('user');
+      const storeUsers = schema.__node.definition.storeMap.getOrCreate('user');
       const wrapper = mount(React.createElement(TestComponentContainer, {
         refrax: {
           users: schema.users

--- a/src/resource/__tests__/RefraxMutableResource.spec.js
+++ b/src/resource/__tests__/RefraxMutableResource.spec.js
@@ -132,7 +132,7 @@ describe('RefraxMutableResource', () => {
 
       beforeEach(() => {
         mutableUsers = new RefraxMutableResource(schema.users);
-        store = schema.__storeMap.getOrCreate('user');
+        store = schema.__node.definition.storeMap.getOrCreate('user');
         expectedDescriptor.store = store;
 
         sinon.spy(mutableUsers, '_generateDescriptor');
@@ -275,7 +275,7 @@ describe('RefraxMutableResource', () => {
 
       beforeEach(() => {
         mutableUsers = new RefraxMutableResource(schema.users);
-        store = expectedDescriptor.store = schema.__storeMap.getOrCreate('user');
+        store = expectedDescriptor.store = schema.__node.definition.storeMap.getOrCreate('user');
 
         sinon.spy(mutableUsers, '_generateDescriptor');
         sinon.spy(store, 'touchResource');
@@ -425,7 +425,7 @@ describe('RefraxMutableResource', () => {
 
       beforeEach(() => {
         mutableUsers = new RefraxMutableResource(schema.users);
-        store = expectedDescriptor.store = schema.__storeMap.getOrCreate('user');
+        store = expectedDescriptor.store = schema.__node.definition.storeMap.getOrCreate('user');
 
         sinon.spy(mutableUsers, '_generateDescriptor');
         sinon.spy(store, 'touchResource');

--- a/src/resource/__tests__/RefraxResource.spec.js
+++ b/src/resource/__tests__/RefraxResource.spec.js
@@ -75,7 +75,7 @@ describe('RefraxResource', () => {
     it('should look and behave like a Resource', () => {
       const onLoad = sinon.spy();
       const onChange = sinon.spy();
-      const store = schema.__storeMap.getOrCreate('user');
+      const store = schema.__node.definition.storeMap.getOrCreate('user');
       sinon.spy(store, 'once');
 
       const resource = new RefraxResource(schema.users);
@@ -259,7 +259,7 @@ describe('RefraxResource', () => {
 
     describe('_subscribeToStore', () => {
       it('correctly sets up a weakly referenced subscriber', () => {
-        const store = schema.__storeMap.getOrCreate('user');
+        const store = schema.__node.definition.storeMap.getOrCreate('user');
         const descriptor = new RefraxResourceDescriptor(null, ACTION_GET, schema.users.__stack);
         const resource = new RefraxResource(schema.users, new RefraxOptions({ noSubscribe: true }));
         const onChange = sinon.spy();
@@ -337,7 +337,7 @@ describe('RefraxResource', () => {
       describe('with default behavior', () => {
         it('correctly invalidates cache and fetches', () => {
           const resource = new RefraxResource(schema.users);
-          const store = schema.__storeMap.getOrCreate('user');
+          const store = schema.__node.definition.storeMap.getOrCreate('user');
           sinon.spy(store, 'invalidate');
 
           return wait_for_promise(() => resource.status === STATUS_COMPLETE)
@@ -368,7 +368,7 @@ describe('RefraxResource', () => {
       describe('with noFetchGet', () => {
         it('correctly invalidates cache and does not fetch', () => {
           const resource = new RefraxResource(schema.users);
-          const store = schema.__storeMap.getOrCreate('user');
+          const store = schema.__node.definition.storeMap.getOrCreate('user');
           sinon.spy(store, 'invalidate');
 
           return wait_for_promise(() => resource.status === STATUS_COMPLETE)

--- a/src/resource/__tests__/RefraxResourceDescriptor.spec.js
+++ b/src/resource/__tests__/RefraxResourceDescriptor.spec.js
@@ -189,7 +189,7 @@ describe('RefraxResourceDescriptor', () => {
             params: {},
             partial: FRAGMENT_DEFAULT,
             payload: {},
-            store: schema.__storeMap.__map['project'],
+            store: schema.__node.definition.storeMap.__map['project'],
             type: 'project',
             valid: true,
             basePath: '/projects',
@@ -217,7 +217,7 @@ describe('RefraxResourceDescriptor', () => {
             params: { projectId: 123 },
             partial: FRAGMENT_DEFAULT,
             payload: {},
-            store: schema.__storeMap.__map['user'],
+            store: schema.__node.definition.storeMap.__map['user'],
             type: 'user',
             valid: true,
             basePath: '/projects/123/users',
@@ -255,7 +255,7 @@ describe('RefraxResourceDescriptor', () => {
             params: {},
             partial: FRAGMENT_DEFAULT,
             payload: {},
-            store: schema.__storeMap.__map['project'],
+            store: schema.__node.definition.storeMap.__map['project'],
             type: 'project',
             valid: true,
             basePath: '/projects/123',
@@ -283,7 +283,7 @@ describe('RefraxResourceDescriptor', () => {
             params: {},
             partial: FRAGMENT_DEFAULT,
             payload: {},
-            store: schema.__storeMap.__map['user'],
+            store: schema.__node.definition.storeMap.__map['user'],
             type: 'user',
             valid: true,
             basePath: '/projects/123/users/321',
@@ -310,7 +310,7 @@ describe('RefraxResourceDescriptor', () => {
             params: {},
             partial: FRAGMENT_DEFAULT,
             payload: {},
-            store: schema.__storeMap.__map['setting'],
+            store: schema.__node.definition.storeMap.__map['setting'],
             type: 'setting',
             valid: true,
             basePath: '/settings',
@@ -338,7 +338,7 @@ describe('RefraxResourceDescriptor', () => {
             params: {},
             partial: FRAGMENT_DEFAULT,
             payload: {},
-            store: schema.__storeMap.__map['setting'],
+            store: schema.__node.definition.storeMap.__map['setting'],
             type: 'setting',
             valid: true,
             basePath: '/projects/123/settings',
@@ -593,7 +593,7 @@ describe('RefraxResourceDescriptor', () => {
               params: {},
               partial: FRAGMENT_DEFAULT,
               payload: {},
-              store: schema.__storeMap.__map['project'],
+              store: schema.__node.definition.storeMap.__map['project'],
               type: 'project',
               valid: true,
               basePath: '/projects/123',
@@ -625,7 +625,7 @@ describe('RefraxResourceDescriptor', () => {
               params: {},
               partial: FRAGMENT_DEFAULT,
               payload: {},
-              store: schema.__storeMap.__map['user'],
+              store: schema.__node.definition.storeMap.__map['user'],
               type: 'user',
               valid: true,
               basePath: '/projects/123/users/321',
@@ -653,7 +653,7 @@ describe('RefraxResourceDescriptor', () => {
         expect(descriptor.store)
           .to.not.equal(RefraxResourceDescriptor.storeMap.getOrCreate(descriptor.type));
         expect(descriptor.store)
-          .to.equal(schema.__storeMap.getOrCreate(descriptor.type));
+          .to.equal(schema.__node.definition.storeMap.getOrCreate(descriptor.type));
       });
     });
   });

--- a/src/response/__tests__/processResponse.spec.js
+++ b/src/response/__tests__/processResponse.spec.js
@@ -86,7 +86,7 @@ describe('processResponse', () => {
       });
 
       it('should translate action correctly to store', () => {
-        const store = schema.__storeMap.getOrCreate('user');
+        const store = schema.__node.definition.storeMap.getOrCreate('user');
         const descriptor1 = new RefraxResourceDescriptor(null, ACTION_GET, schema.users.__stack);
         const descriptor2 = new RefraxResourceDescriptor(null, ACTION_DELETE, schema.users.__stack);
         const options = { foo: 123 };

--- a/src/schema/RefraxSchema.js
+++ b/src/schema/RefraxSchema.js
@@ -8,19 +8,48 @@
 const RefraxStoreMap = require('RefraxStoreMap');
 const RefraxSchemaNode = require('RefraxSchemaNode');
 const RefraxSchemaPath = require('RefraxSchemaPath');
+const RefraxAdapter = require('RefraxAdapter');
+const XHRAdapter = require('XHRAdapter');
+const RefraxTools = require('RefraxTools');
 const RefraxConstants = require('RefraxConstants');
 const CLASSIFY_SCHEMA = RefraxConstants.classify.schema;
 
 
-class RefraxSchema extends RefraxSchemaPath {
-  constructor() {
-    const storeMap = new RefraxStoreMap();
-    // TODO: store our map/self in SchemaNode?
-    super(new RefraxSchemaNode(CLASSIFY_SCHEMA, null, {
-      storeMap: storeMap
-    }));
+function validateDefinition(definition) {
+  if (!RefraxTools.isPlainObject(definition)) {
+    throw new TypeError(
+      'RefraxSchema - You\'re attempting to pass an invalid definition of type `' + typeof(definition) + '`. ' +
+      'A valid definition type is a regular object.'
+    );
+  }
 
-    Object.defineProperty(this, '__storeMap', {value: storeMap});
+  if ('storeMap' in definition && !(definition.storeMap instanceof RefraxStoreMap)) {
+    throw new TypeError(
+      'RefraxSchema - Option `storeMap` can only be of type RefraxStoreMap but found ' +
+      'type `' + typeof(definition.storeMap) + '`.'
+    );
+  }
+
+  if ('adapter' in definition && !(definition.adapter instanceof RefraxAdapter)) {
+    throw new TypeError(
+      'RefraxSchema - Option `adapter` can only be of type RefraxAdapter but found ' +
+      'type `' + typeof(definition.adapter) + '`.'
+    );
+  }
+
+  return definition;
+}
+
+class RefraxSchema extends RefraxSchemaPath {
+  constructor(definition = {}) {
+    validateDefinition(definition);
+
+    definition = RefraxTools.extend({
+      adapter: new XHRAdapter(),
+      storeMap: new RefraxStoreMap()
+    }, definition);
+
+    super(new RefraxSchemaNode(CLASSIFY_SCHEMA, null, definition));
   }
 
   toString() {
@@ -28,11 +57,13 @@ class RefraxSchema extends RefraxSchemaPath {
   }
 
   invalidate() {
-    this.__storeMap.invalidate.apply(this.__storeMap, arguments);
+    const storeMap = this.__node.definition.storeMap;
+    storeMap.invalidate.apply(storeMap, arguments);
   }
 
   reset() {
-    this.__storeMap.reset.apply(this.__storeMap, arguments);
+    const storeMap = this.__node.definition.storeMap;
+    storeMap.reset.apply(storeMap, arguments);
   }
 }
 

--- a/src/schema/RefraxSchemaNode.js
+++ b/src/schema/RefraxSchemaNode.js
@@ -17,7 +17,8 @@ const CLASSIFY_ITEM = RefraxConstants.classify.item;
 const validDefinitionKeys = {};
 
 validDefinitionKeys[CLASSIFY_SCHEMA] = [
-  'storeMap'
+  'storeMap',
+  'adapter'
 ];
 
 validDefinitionKeys[CLASSIFY_NAMESPACE] = [
@@ -159,10 +160,10 @@ class RefraxSchemaNode {
     // TODO: Do we need to classify this anymore?
     definition.classify = type;
 
-    Object.defineProperty(this, 'type', {value: type});
-    Object.defineProperty(this, 'identifier', {value: identifier});
-    Object.defineProperty(this, 'definition', {value: definition});
-    Object.defineProperty(this, 'leafs', {value: {}});
+    Object.defineProperty(this, 'type', { value: type });
+    Object.defineProperty(this, 'identifier', { value: identifier });
+    Object.defineProperty(this, 'definition', { value: definition });
+    Object.defineProperty(this, 'leafs', { value: {} });
   }
 }
 

--- a/src/schema/__tests__/RefraxSchema.spec.js
+++ b/src/schema/__tests__/RefraxSchema.spec.js
@@ -17,20 +17,20 @@ describe('RefraxSchema', function() {
     describe('reset', function() {
       it('correctly forwards to storeMap', function() {
         var schema = new RefraxSchema();
-        sinon.spy(schema.__storeMap, 'reset');
+        sinon.spy(schema.__node.definition.storeMap, 'reset');
 
         schema.reset();
-        expect(schema.__storeMap.reset.callCount).to.equal(1);
+        expect(schema.__node.definition.storeMap.reset.callCount).to.equal(1);
       });
     });
 
     describe('invalidate', function() {
       it('correctly forwards to storeMap', function() {
         var schema = new RefraxSchema();
-        sinon.spy(schema.__storeMap, 'invalidate');
+        sinon.spy(schema.__node.definition.storeMap, 'invalidate');
 
         schema.invalidate();
-        expect(schema.__storeMap.invalidate.callCount).to.equal(1);
+        expect(schema.__node.definition.storeMap.invalidate.callCount).to.equal(1);
       });
     });
   });


### PR DESCRIPTION
This PR adds Adapter support & associated option to `Schema` objects.

Adapters like `XHRAdapter` / `LocalStorageAdapter` / `SessionStorageAdapter` are now available on the main `Refrax` import and can be passed via:
```js
new Schema({ adapter: ... })
```
Note: Session defaults to `XHRAdapter` by default.