### PR TITLE
Fix Resource touch onEvent bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## v0.7.2
+
+- **Bugfix** Fixed `Resource` store `onEvent` ignoring touch end events
+
 # Released
 
 ## [v0.7.1](https://github.com/netarc/refrax/compare/v0.7.0...v0.7.1)

--- a/scripts/test/TestSupport.ts
+++ b/scripts/test/TestSupport.ts
@@ -14,6 +14,9 @@ import * as Promise from 'bluebird';
 import { axiosMock, Request } from './AxiosMock';
 const map = require('mocha/lib/utils.js').map;
 
+import { IAction } from 'actions/action';
+import { Resource } from 'resource/resource';
+
 // @ts-ignore global access
 global.window = {};
 // @ts-ignore readonly write-protect
@@ -108,7 +111,7 @@ export const delay_for = (delay = 5) =>
       }, delay);
     });
 
-export const delay_for_resource_request = (resource: any) =>
+export const delay_for_resource_request = (resource: Resource) =>
   () => {
     // pre-create our error so we can use its stack-trace when we reject
     const err = new Error('delay timeout!');
@@ -121,13 +124,13 @@ export const delay_for_resource_request = (resource: any) =>
       });
 
       timeout = setTimeout(() => {
-        disposer();
+        disposer.dispose();
         reject(err);
       }, 50);
     });
   };
 
-export const delay_for_action = (resource: any) =>
+export const delay_for_action = (resource: IAction) =>
   () => {
     // pre-create our error so we can use its stack-trace when we reject
     const err = new Error('delay timeout!');
@@ -140,7 +143,7 @@ export const delay_for_action = (resource: any) =>
       });
 
       timeout = setTimeout(() => {
-        disposer();
+        disposer.dispose();
         reject(err);
       }, 50);
     });

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -89,9 +89,10 @@ export class Resource extends BaseResource {
 
   _subscribeToStore(descriptor: ResourceDescriptor): void {
     const onEvent = (event: IKeyValue) => {
-      // 'touch' actions that originate from ourself come from `_fetchFragment` so we can
-      // safely ignore them as that implicitly updates our cache state
-      if (event.action === IStoreEvent.touch && event.invoker === this) {
+      // Ignore the initial 'touch' action when starting to fetch but not when the request finishes
+      if (event.action === IStoreEvent.touch &&
+          event.invoker === this &&
+          event.touch.timestamp <= ITimestamp.loading) {
         return;
       }
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -94,7 +94,7 @@ export class Store extends Eventable {
 
   touchResource(resourceDescriptor: ResourceDescriptor, touch: IKeyValue, options: IKeyValue = {}): void {
     const touched = this.cache.touch(resourceDescriptor, touch);
-    this._notifyChange(IStoreEvent.touch, touched, options);
+    this._notifyChange(IStoreEvent.touch, touched, extend({}, options, { touch }));
   }
 
   updateResource(resourceDescriptor: ResourceDescriptor, data: any, status?: IStatus, options: IKeyValue = {}): void {


### PR DESCRIPTION
This PR fixes an issue where a `Resource` store `onEvent` hook would ignore all touch events instead of just request start touch events.